### PR TITLE
Refactor environment variable access using import.meta.env across the…

### DIFF
--- a/src/components/admin/ProductManagement.svelte
+++ b/src/components/admin/ProductManagement.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from "svelte";
   import type { Product } from "../../types";
-  const API_URL = process.env.API_URL;
+  const API_URL = import.meta.env.VITE_API_URL;
   import { fade } from "svelte/transition";
 
   export let products: Product[];

--- a/src/components/admin/SalesSummary.svelte
+++ b/src/components/admin/SalesSummary.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import Chart from "chart.js/auto";
   import type { Sale } from "../../types";
-  const API_URL = process.env.API_URL;
+  const API_URL = import.meta.env.VITE_API_URL;
 
   let canvas: HTMLCanvasElement;
   let chart: Chart | null = null;

--- a/src/pages/Inventory.svelte
+++ b/src/pages/Inventory.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { currentRoute } from "../stores/route";
-  const API_URL = process.env.API_URL;
+  const API_URL = import.meta.env.VITE_API_URL;
   import type { Product } from "../types";
   import ProductManagement from "../components/admin/ProductManagement.svelte";
 

--- a/src/pages/Login.svelte
+++ b/src/pages/Login.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { updateRoute } from "../stores/route";
-  const API_URL = process.env.API_URL;
+  const API_URL = import.meta.env.VITE_API_URL;
 
   let username = "";
   let password = "";

--- a/src/pages/Products.svelte
+++ b/src/pages/Products.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import { cart } from "../stores/cartStore";
   import type { CartItem } from "../stores/cartStore";
-  const API_URL = process.env.API_URL;
+  const API_URL = import.meta.env.VITE_API_URL;
   interface Product {
     _id: string;
     name: string;

--- a/src/stores/productStore.ts
+++ b/src/stores/productStore.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 import type { Product } from '../types';
-const API_URL = process.env.API_URL;
+const API_URL = import.meta.env.VITE_API_URL;
 
 function createProductStore() {
   const { subscribe, set, update } = writable<Product[]>([]);


### PR DESCRIPTION
This pull request addresses inconsistency in access to environment variables across the application, specifically adapting the access method for better integration with Vite and Svelte. Previously, environment variables were accessed directly through process.env.API_URL, which is not best practice in Vite environments as it can override the environment variable.

![image](https://github.com/user-attachments/assets/d9ce9b26-c660-47e4-8aba-6340da8a1f7c)

![image](https://github.com/user-attachments/assets/3ce95afe-3452-4e55-afdb-43d648bf61d7)

This has been refactored to use import.meta.env.VITE_API_URL to ensure proper loading of environment variables.

![image](https://github.com/user-attachments/assets/dbd15143-8e81-41e9-b5d6-fe9385710e54)

Key changes:

Replaced all instances of Process.env.API_URL with import.meta.env.VITE_API_URL.
Ensured that the new environment variable handling is consistent across all components and services that require API access.